### PR TITLE
Workaround for mactex-no-gui brew broken URL

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -48,7 +48,7 @@ jobs:
           # is a 404. At http://mirror.ctan.org/systems/mac/mactex/ you can see
           # this was updated. Try just fetching and installing that .pkg
           # directly as a workaround until brew formula fixed.
-          wget "https://mirrors.concertpass.com/tex-archive/systems/mac/mactex/mactex-20220321.pkg"
+          wget -q "https://mirrors.concertpass.com/tex-archive/systems/mac/mactex/mactex-20220321.pkg"
           # https://apple.stackexchange.com/questions/72226/installing-pkg-with-terminal
           installer -pkg ./mactex-20220321.pkg -target /
           echo "/usr/local/opt" >> $GITHUB_PATH

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -43,7 +43,13 @@ jobs:
       - name: Download and install dependencies
         run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          # https://formulae.brew.sh/cask/mactex-no-gui has a link to
+          # http://mirror.ctan.org/systems/mac/mactex/mactex-20210328.pkg which
+          # is a 404. At http://mirror.ctan.org/systems/mac/mactex/ you can see
+          # this was updated. Try just fetching and installing that .pkg
+          # directly as a workaround until brew formula fixed.
           wget "https://mirrors.concertpass.com/tex-archive/systems/mac/mactex/mactex-20220321.pkg"
+          # https://apple.stackexchange.com/questions/72226/installing-pkg-with-terminal
           installer -pkg ./mactex-20220321.pkg -target /
           echo "/usr/local/opt" >> $GITHUB_PATH
           echo "/Library/TeX/texbin" >> $GITHUB_PATH

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -50,7 +50,7 @@ jobs:
           # directly as a workaround until brew formula fixed.
           wget -q "https://mirrors.concertpass.com/tex-archive/systems/mac/mactex/mactex-20220321.pkg"
           # https://apple.stackexchange.com/questions/72226/installing-pkg-with-terminal
-          installer -pkg ./mactex-20220321.pkg -target /
+          sudo installer -pkg ./mactex-20220321.pkg -target /
           echo "/usr/local/opt" >> $GITHUB_PATH
           echo "/Library/TeX/texbin" >> $GITHUB_PATH
           brew install pandoc

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -43,7 +43,8 @@ jobs:
       - name: Download and install dependencies
         run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          brew install --cask mactex-no-gui
+          wget "https://mirrors.concertpass.com/tex-archive/systems/mac/mactex/mactex-20220321.pkg"
+          installer -pkg ./mactex-20220321.pkg -target /
           echo "/usr/local/opt" >> $GITHUB_PATH
           echo "/Library/TeX/texbin" >> $GITHUB_PATH
           brew install pandoc


### PR DESCRIPTION
Immediate workaround for the update of mactex-no-gui. See comments in build-and-publish for details, duplicated here.

https://formulae.brew.sh/cask/mactex-no-gui has a link to http://mirror.ctan.org/systems/mac/mactex/mactex-20210328.pkg which is a 404. At http://mirror.ctan.org/systems/mac/mactex/ you can see this was updated. Try just fetching and installing that .pkg directly as a workaround until brew formula fixed.