### PR TITLE
revert changes for mactex-no-gui

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -43,14 +43,7 @@ jobs:
       - name: Download and install dependencies
         run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          # https://formulae.brew.sh/cask/mactex-no-gui has a link to
-          # http://mirror.ctan.org/systems/mac/mactex/mactex-20210328.pkg which
-          # is a 404. At http://mirror.ctan.org/systems/mac/mactex/ you can see
-          # this was updated. Try just fetching and installing that .pkg
-          # directly as a workaround until brew formula fixed.
-          wget -q "https://mirrors.concertpass.com/tex-archive/systems/mac/mactex/mactex-20220321.pkg"
-          # https://apple.stackexchange.com/questions/72226/installing-pkg-with-terminal
-          sudo installer -pkg ./mactex-20220321.pkg -target /
+          brew install --cask mactex-no-gui
           echo "/usr/local/opt" >> $GITHUB_PATH
           echo "/Library/TeX/texbin" >> $GITHUB_PATH
           brew install pandoc

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -43,7 +43,14 @@ jobs:
       - name: Download and install dependencies
         run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          brew install --cask mactex-no-gui
+          # https://formulae.brew.sh/cask/mactex-no-gui has a link to
+          # http://mirror.ctan.org/systems/mac/mactex/mactex-20210328.pkg which
+          # is a 404. At http://mirror.ctan.org/systems/mac/mactex/ you can see
+          # this was updated. Try just fetching and installing that .pkg
+          # directly as a workaround until brew formula fixed.
+          wget -q "https://mirrors.concertpass.com/tex-archive/systems/mac/mactex/mactex-20220321.pkg"
+          # https://apple.stackexchange.com/questions/72226/installing-pkg-with-terminal
+          sudo installer -pkg ./mactex-20220321.pkg -target /
           echo "/usr/local/opt" >> $GITHUB_PATH
           echo "/Library/TeX/texbin" >> $GITHUB_PATH
           brew install pandoc


### PR DESCRIPTION
it appears the brew formula is referring to the right 2022.0321 version now https://formulae.brew.sh/cask/mactex-no-gui

🤪

The git history looks silly because I made a mistake, but the net diff is pretty apparent.